### PR TITLE
fix: options type

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -31,7 +31,7 @@ function isValidAction(action) {
   return false
 }
 
-export function createMiddleware<T extends any>(engine: StorageEngine, options: MiddlewareOptions = {}) {
+export function createMiddleware<T extends any>(engine: StorageEngine, options: MiddlewareOptions<T> = {}) {
   const opts = Object.assign({ disableDispatchSaveAction: false }, options)
 
   return ({ dispatch, getState }: ReduxStore<T>) => {
@@ -47,7 +47,7 @@ export function createMiddleware<T extends any>(engine: StorageEngine, options: 
 
       if (!isBlacklisted) {
         const transform = options.transform || defaultTransformer
-        const saveState = transform<T>(getState())
+        const saveState = transform(getState())
         const saveAction = save(saveState) as ActionMeta<any, any>
 
         if (process.env.NODE_ENV !== 'production') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export type StorageEngine = {
 
 export type MiddlewareWhitelist = string[] | ((action: BaseAction) => boolean)
 
-export type MiddlewareOptions = {
+export type MiddlewareOptions<T> = {
   /**
    * Return `true` for any action that should be accepted by the middleware.
    */
@@ -16,7 +16,7 @@ export type MiddlewareOptions = {
   /**
    * Transform and return a new state before saving to the psrovided storage engine.
    */
-  transform?: <T extends any>(state: T) => T
+  transform?: (state: T) => T
 
   /**
    * Don't dispatch a `REDUX_PERSISTENCE_SAVE` action after saving to the provided storage engine, `false` by default.


### PR DESCRIPTION
Define `MiddlewareOptions` as generic instead of `MiddlewareOptions['transform']`